### PR TITLE
Update pip installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ conda env create -f STICI1.yml
 ```
 In case the above solution doesn't work, please try the following after creating a fresh environment:
 ```
-pip3 install tensorflow[and-cuda]==2.14.1 joblib==1.4.2 pandas==2.2.3 numpy==1.26.4 psutil==6.1.1 scikit-learn==1.6.1 scipy==1.13.1 tqdm
+pip3 install tensorflow[and-cuda]==2.14.1 joblib==1.4.2 pandas==2.2.3 numpy==1.26.4 psutil==6.1.1 scikit-learn==1.6.1 scipy==1.13.1 tqdm datatable==1.1.0 tensorflow-addons==0.23.0
 ```
 Then
 ```


### PR DESCRIPTION
I was unable to install the dependencies with the provided conda yml, so as suggested I attempted to install the dependencies with the provided pip command in a clean environment. Then, I attempted to run STICI_V1.1.py, but got errors that there were not modules for datatable or tensorflow-addons. After I installed these modules using the versions listed in the conda yaml I was able to run STICI_V1.1.py without error. I am assuming that I was able to catch these missing dependencies because I do not primarily code in python. This pull request simply adds these two modules and their versions to the pip install instructions in the README.md.